### PR TITLE
Remove the deprecated UseLogin option from the configuration template

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -170,7 +170,7 @@ class ssh_hardening::server (
       # --------------
 
       # Secure Login directives.
-      'UseLogin'                        => 'no',
+      # 'UseLogin'                        => 'no',  # Option deprecated in OpenSSH 7.4 2016-12-19
       'UsePrivilegeSeparation'          => $priv_sep,
       'PermitUserEnvironment'           => 'no',
       'LoginGraceTime'                  => '30s',


### PR DESCRIPTION
Since OpenSSH >= 7.4 has deprecated the UseLogin option, remove it from the template.
The default setting for UseLogin has been "no" since ~ OpenSSH v3.0.2 (https://www.openssh.com/txt/release-3.0.2) so the risk of this change is relatively low.

Related to https://github.com/dev-sec/ansible-ssh-hardening/pull/141  and https://github.com/dev-sec/ssh-baseline/pull/103