### PR TITLE
Update get_ssh_macs.rb

### DIFF
--- a/lib/puppet/parser/functions/get_ssh_macs.rb
+++ b/lib/puppet/parser/functions/get_ssh_macs.rb
@@ -27,6 +27,9 @@ Puppet::Parser::Functions.newfunction(:get_ssh_macs, :type => :rvalue) do |args|
   macs_59 = {}
   macs_59.default = 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
   macs_59['weak'] = macs_59['default'] + ',hmac-sha1'
+  
+  macs_60 = {}
+  macs_60.default = 'hmac-sha2-512,hmac-sha2-256'
 
   macs_66 = {}
   macs_66.default = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
@@ -43,6 +46,8 @@ Puppet::Parser::Functions.newfunction(:get_ssh_macs, :type => :rvalue) do |args|
   m['ubuntu'] = {}
   m['ubuntu']['12'] = macs_59
   m['ubuntu']['14'] = macs_66
+  m['ubuntu']['18'] = macs_60
+  m['ubuntu']['20'] = macs_60
   m['ubuntu'].default = macs_59
 
   m['debian'] = {}


### PR DESCRIPTION
remove hmac-ripemd160 for ubuntu 18 & 20 that use OpenSSH versions >=7.6
see also https://github.com/dev-sec/puppet-ssh-hardening/issues/69
more of a quick and dirty fix than a thoughtful rework fo the current process,
but it works.